### PR TITLE
feature(implement-jwt): implement jwt on both login and signup

### DIFF
--- a/app/controllers/auth.js
+++ b/app/controllers/auth.js
@@ -1,0 +1,51 @@
+'use strict';
+let mongoose = require('mongoose');
+const User = mongoose.model('User'),
+	   jwt = require('jsonwebtoken'),
+	   config = require('../../config/env/all');
+
+//signup method
+module.exports.signUp = (req, res) =>  {
+	User.findOne({email: req.body.email}, (err, registeredUser) => {
+		if (err) return err;
+		//Check if email does not exists
+		if(!registeredUser) {
+			if (req.body.email && req.body.name && req.body.password) {
+				const user = new User();
+				user.email = req.body.email;
+				user.name = req.body.name;
+				user.password = req.body.password;
+				user.avatar = req.body.avatar;
+				//save the user in the database
+				user.save(function(err, user) {
+					if (err) return err;
+					const token = jwt.sign(user, config.secret, {expiresIn: '24h'});
+					res.json({success: true, message: 'You have successfully signed up!', token:token});
+				});
+			} else {
+				res.send('Authentication failed. No field can be empty!');
+			}
+		} else {
+			res.send('User already available');
+		}
+	});
+}
+//login method
+module.exports.login = (req, res) => {
+	User.findOne({email: req.body.email}, (err, user) => {
+		if (err) return err;
+		//check if email does not exists
+		if (!user) {
+			res.json({success: false, message: 'Incorrect email or password'});
+		} else {
+			//check if user password against the one the database
+			if (!user.authenticate(req.body.password)) {
+				res.json({success: false, message: 'Authentication failed'});
+			} else {
+				//if everyhing is fine, assign a token to the user
+				const token = jwt.sign(user, config.secret, {expiresIn: '24h'});
+				res.json({success: true, message: 'Login is successfull', token: token});
+			}
+		}
+	});
+}

--- a/config/env/all.js
+++ b/config/env/all.js
@@ -5,5 +5,6 @@ const rootPath = path.normalize(path.join(__dirname, '/../..'));
 module.exports = {
   root: rootPath,
   port: process.env.PORT || 3000,
-  db: process.env.MONGOHQ_URL || 'localhost:27017/cfh'
+  db: process.env.MONGOHQ_URL || 'localhost:27017/cfh',
+  secret: 'kissaSecret'
 };

--- a/config/routes.js
+++ b/config/routes.js
@@ -1,8 +1,9 @@
-var async = require('async');
+'use strict';
+let async = require('async');
 
 module.exports = function(app, passport, auth) {
     //User Routes
-    var users = require('../app/controllers/users');
+    let users = require('../app/controllers/users');
     app.get('/signin', users.signin);
     app.get('/signup', users.signup);
     app.get('/chooseavatars', users.checkAvatar);
@@ -68,26 +69,31 @@ module.exports = function(app, passport, auth) {
     app.param('userId', users.user);
 
     // Answer Routes
-    var answers = require('../app/controllers/answers');
+    let answers = require('../app/controllers/answers');
     app.get('/answers', answers.all);
     app.get('/answers/:answerId', answers.show);
     // Finish with setting up the answerId param
     app.param('answerId', answers.answer);
 
     // Question Routes
-    var questions = require('../app/controllers/questions');
+    let questions = require('../app/controllers/questions');
     app.get('/questions', questions.all);
     app.get('/questions/:questionId', questions.show);
     // Finish with setting up the questionId param
     app.param('questionId', questions.question);
 
     // Avatar Routes
-    var avatars = require('../app/controllers/avatars');
+    let avatars = require('../app/controllers/avatars');
     app.get('/avatars', avatars.allJSON);
 
     //Home route
-    var index = require('../app/controllers/index');
+    let index = require('../app/controllers/index');
     app.get('/play', index.play);
     app.get('/', index.render);
+
+    let jwtAuth = require('../app/controllers/auth');
+    // Setting up new login and sign up route
+    app.post('/api/auth/login', jwtAuth.login);
+    app.post('/api/auth/signup', jwtAuth.signUp);
 
 };

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "gulp-cli": "^1.2.2",
     "gulp-filter": "^4.0.0",
     "jade": "~0.35.0",
+    "jsonwebtoken": "^7.1.9",
     "karma": "^1.3.0",
     "mean-logger": "~0.0.1",
     "mongoose": "~3.6.20",


### PR DESCRIPTION
#134209515, #134209513 Give users jwt on both successful login and signup
#### What does this PR do?
This PR implements json web token /api/auth endpoints
#### Description of Task to be completed?
Users once authenticated via the signup or login api should be returned a JWT to be required on subsequent call to all other endpoints that require authentication
#### How should this be manually tested?
It can be tested using postman rest client
#### Any background context you want to provide?
No background context
#### What are the relevant pivotal tracker stories?
Users should receive a JWT on successful signup and login
#### Screenshots (if appropriate)
None
#### Questions:
No questions